### PR TITLE
Import fix

### DIFF
--- a/pyACA/__init__.py
+++ b/pyACA/__init__.py
@@ -15,6 +15,7 @@ from .ToolReadAudio import ToolReadAudio
 from .ToolPreprocAudio import ToolPreprocAudio
 from .FeatureSpectralCentroid import FeatureSpectralCentroid
 from .FeatureSpectralCrestFactor import FeatureSpectralCrestFactor
+from .FeatureSpectralDecrease import FeatureSpectralDecrease
 from .FeatureSpectralFlatness import FeatureSpectralFlatness
 from .FeatureSpectralFlux import FeatureSpectralFlux
 from .FeatureSpectralKurtosis import FeatureSpectralKurtosis

--- a/pyACA/computeBeatHisto.py
+++ b/pyACA/computeBeatHisto.py
@@ -16,9 +16,9 @@ computes a simple beat histogram
 
 import numpy as np
 
-from .computeNoveltyFunction import computeNoveltyFunction
-from .ToolComputeHann import ToolComputeHann
-from .ToolReadAudio import ToolReadAudio
+from pyACA.computeNoveltyFunction import computeNoveltyFunction
+from pyACA.ToolComputeHann import ToolComputeHann
+from pyACA.ToolReadAudio import ToolReadAudio
 
 def computeBeatHisto(afAudioData, f_s, afWindow=None, iBlockLength=1024, iHopLength=8):
 

--- a/pyACA/computeFeature.py
+++ b/pyACA/computeFeature.py
@@ -42,9 +42,9 @@ from scipy.signal import spectrogram
 import matplotlib.pyplot as plt
 
 import pyACA
-from .ToolPreprocAudio import ToolPreprocAudio
-from .ToolComputeHann import ToolComputeHann
-from .ToolReadAudio import ToolReadAudio
+from pyACA.ToolPreprocAudio import ToolPreprocAudio
+from pyACA.ToolComputeHann import ToolComputeHann
+from pyACA.ToolReadAudio import ToolReadAudio
 
 
 def computeFeature(cFeatureName, afAudioData, f_s, afWindow=None, iBlockLength=4096, iHopLength=2048):

--- a/pyACA/computeKey.py
+++ b/pyACA/computeKey.py
@@ -17,10 +17,10 @@ computes the musical key of an input audio file
 import numpy as np
 from scipy.signal import spectrogram
 
-from .ToolComputeHann import ToolComputeHann
-from .FeatureSpectralPitchChroma import FeatureSpectralPitchChroma
-from .ToolPreprocAudio import ToolPreprocAudio
-from .ToolReadAudio import ToolReadAudio
+from pyACA.ToolComputeHann import ToolComputeHann
+from pyACA.FeatureSpectralPitchChroma import FeatureSpectralPitchChroma
+from pyACA.ToolPreprocAudio import ToolPreprocAudio
+from pyACA.ToolReadAudio import ToolReadAudio
 
 def computeKey(afAudioData, f_s, afWindow=None, iBlockLength=4096, iHopLength=2048):
 

--- a/pyACA/computeNoveltyFunction.py
+++ b/pyACA/computeNoveltyFunction.py
@@ -30,9 +30,9 @@ from scipy.signal import filtfilt
 from scipy.signal import find_peaks
 
 import pyACA
-from .ToolPreprocAudio import ToolPreprocAudio
-from .ToolComputeHann import ToolComputeHann
-from .ToolReadAudio import ToolReadAudio
+from pyACA.ToolPreprocAudio import ToolPreprocAudio
+from pyACA.ToolComputeHann import ToolComputeHann
+from pyACA.ToolReadAudio import ToolReadAudio
 
 
 def computeNoveltyFunction(cNoveltyName, afAudioData, f_s, afWindow=None, iBlockLength=4096, iHopLength=512):

--- a/pyACA/computePitch.py
+++ b/pyACA/computePitch.py
@@ -28,9 +28,9 @@ from scipy.signal import spectrogram
 import matplotlib.pyplot as plt
 
 import pyACA
-from .ToolPreprocAudio import ToolPreprocAudio
-from .ToolComputeHann import ToolComputeHann
-from .ToolReadAudio import ToolReadAudio
+from pyACA.ToolPreprocAudio import ToolPreprocAudio
+from pyACA.ToolComputeHann import ToolComputeHann
+from pyACA.ToolReadAudio import ToolReadAudio
 
 
 def computePitch(cPitchTrackName, afAudioData, f_s, afWindow=None, iBlockLength=4096, iHopLength=2048):


### PR DESCRIPTION
compute* scripts can be run directly now.

- Relative imports replaced by absolute imports in `compute*.py` modules. 
- `FeatureSpectralDecrease` module added to `__init__.py`.
